### PR TITLE
MySqlServer dispose tweaks

### DIFF
--- a/src/SqlStreamStore.MySql.Tests/Server/MySqlServer.cs
+++ b/src/SqlStreamStore.MySql.Tests/Server/MySqlServer.cs
@@ -4,7 +4,6 @@
     using System.Data;
     using System.Diagnostics;
     using System.IO;
-    using System.Net.Sockets;
     using System.Threading;
     using System.Threading.Tasks;
     using MySql.Data.MySqlClient;
@@ -51,6 +50,7 @@
                 $@"--lc-messages-dir=""{mysqlDirectory}""",
                 $@"--datadir=""{_dataDirectory}""",
                 "--skip-grant-tables",
+                "--bind-address=127.0.0.1",
                 $"--port={ServerPort}",
                 "--innodb_fast_shutdown=2",
                 "--innodb_doublewrite=OFF",
@@ -152,13 +152,18 @@
 
             _process?.Dispose();
 
-            try
+            var stopwatch = Stopwatch.StartNew();
+            while(stopwatch.ElapsedMilliseconds < 1000)
             {
-                Directory.Delete(_dataDirectory);
-            }
-            catch(Exception ex)
-            {
-                _testOutputHelper.WriteLine($"{ex}");
+                try
+                {
+                    Directory.Delete(_dataDirectory, true);
+                    break;
+                }
+                catch(IOException)
+                {
+                    Thread.Sleep(100);
+                }
             }
         }
    }

--- a/src/SqlStreamStore.MySql.Tests/SqlStreamStore.MySql.Tests.csproj
+++ b/src/SqlStreamStore.MySql.Tests/SqlStreamStore.MySql.Tests.csproj
@@ -17,11 +17,11 @@
   <ItemGroup>
     <Content Include=".mysql\mysql-5.6.37-winx64\bin\mysqld.exe">
       <Link>.mysql\mysqld.exe</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include=".mysql\mysql-5.6.37-winx64\share\english\errmsg.sys">
       <Link>.mysql\errmsg.sys</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
   <ItemGroup>

--- a/src/SqlStreamStore.MySql/MySqlStreamStore.StreamMetadata.cs
+++ b/src/SqlStreamStore.MySql/MySqlStreamStore.StreamMetadata.cs
@@ -5,7 +5,6 @@
     using System.Threading.Tasks;
     using SqlStreamStore.Streams;
     using SqlStreamStore.Infrastructure;
-    using StreamStoreStore.Json;
 
     public partial class MySqlStreamStore
     {


### PR DESCRIPTION
Bind mysqld to loopback address.
Retry data directory cleanup up to one second (bit of a race condition between process shutdown and file lock releasing).
Also removed some redundant using directives.